### PR TITLE
docs: revise security reporting guidelines and escalation process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,7 @@
 
 ## Reporting a Vulnerability
 
-Please report security issues **privately**:
-
-- Email: jlipps@cloudgrey.io (Jonathan Lipps) and christian@saucelabs.com (Christian Bromann)
-- Or use GitHub’s **Report a vulnerability** form on this repository (Security tab).
+Please report security issues **privately** using GitHub’s **Report a vulnerability** form on this repository (Security tab).
 
 **Do not** file public GitHub issues for security problems.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,29 @@
 # Reporting Security Issues
 
-If you believe you have found a security vulnerability in Appium, we encourage you to let us know right away. We will investigate all legitimate reports and do our best to quickly fix the problem.
+# Security Policy
 
-Please contact any of the following organizers directly:
+## Reporting a Vulnerability
 
-* Jonathan Lipps [email](mailto:jlipps@cloudgrey.io) [twitter](https://twitter.com/jlipps)
-* Christian Bromann [email](mailto:christian@saucelabs.com) [twitter](https://twitter.com/bromann)
+Please report security issues **privately**:
+
+- Email: jlipps@cloudgrey.io (Jonathan Lipps) and christian@saucelabs.com (Christian Bromann)
+- Or use GitHub’s **Report a vulnerability** form on this repository (Security tab).
+
+**Do not** file public GitHub issues for security problems.
+
+When reporting, please include:
+- Affected project/repo and version(s)
+- Impact and component(s) involved
+- Reproduction steps or PoC (if available)
+- Your contact and preferred credit name
+
+If you do not receive an acknowledgement of your report within **6 business days**, or if you cannot find a private security contact for the project, you may **escalate to the OpenJS Foundation CNA** at `security@lists.openjsf.org`.
+
+If the project acknowledges your report but does not provide any further response or engagement within **14 days**, escalation is also appropriate.
+
+## Coordination & Disclosure
+
+We follow coordinated vulnerability disclosure:
+- We will acknowledge your report, assess impact, and work on a fix.
+- We aim to provide status updates at reasonable intervals until resolution.
+- We will publish a security advisory (and **CVE via the OpenJS CNA when applicable**) once a fix or mitigation is available. We credit reporters by default unless you request otherwise.


### PR DESCRIPTION
👋 Hi everyone! We’re @UlisesGascon and @RafaelGSS, working with the OpenJS Foundation as part of [the Alpha-Omega initiative](https://openjsf.org/blog/openjs-security-checkpoint-2025-so-far). Our focus is supporting OpenJS projects in strengthening their security posture. We can help with things like:

- Reviewing or creating security documentation (e.g., SECURITY.md, incident response plans...)
- Supporting vulnerability handling and escalation (reporting, triage, CVEs, disputes)
- Reviewing repo configurations and GitHub security settings
- Sharing best practices (e.g., OSSF Scorecard)
- Answering general questions on licenses, compliance, or incident response

:sparkles: We’re here as a resource for the Appium team and happy to collaborate on whatever is most useful for you. Looking forward to working together!


**References:**
- https://github.com/openjs-foundation/cross-project-council/pull/1588
- https://openjsf.org/blog/openjs-foundation-cna
- https://openjsf.org/blog/security-support-for-openjs-projects